### PR TITLE
Fix #25 -- Use country names for flag emojis if possible

### DIFF
--- a/app/emoji-store/service.js
+++ b/app/emoji-store/service.js
@@ -21,7 +21,7 @@ function countryName(code) {
 
 function humanize(word, category) {
   if (word.length === 2 && category === 'flags') {
-    return countryName(word);
+    return countryName(word.toUpperCase());
   }
   return (word || '').replace(/_/g, ' ');
 }

--- a/app/emoji-store/service.js
+++ b/app/emoji-store/service.js
@@ -2,8 +2,11 @@ import Ember from 'ember';
 import emojilib from 'npm:emojilib';
 import countries from 'npm:isoc';
 
-function humanize(category) {
-  return (category || '').replace(/_/g, ' ');
+function humanize(word, category) {
+  if (word.length == 2 && category === 'flags') {
+    return countryName(word);
+  }
+  return (word || '').replace(/_/g, ' ');
 }
 
 function keywordMatches(keyword='', query='') {
@@ -42,10 +45,7 @@ export default Ember.Service.extend({
   seedEmoji() {
     for (let name of Object.keys(emojilib.lib)) {
       let {char, category, keywords} = emojilib.lib[name];
-      let emoji = {
-        name: (category === 'flags')?countryName(name.toUpperCase()):humanize(name),
-        char,
-      };
+      let emoji = {name: humanize(name, category), char};
       if (!char) {
         continue;
       }

--- a/app/emoji-store/service.js
+++ b/app/emoji-store/service.js
@@ -2,18 +2,6 @@ import Ember from 'ember';
 import emojilib from 'npm:emojilib';
 import countries from 'npm:isoc';
 
-function humanize(word, category) {
-  if (word.length == 2 && category === 'flags') {
-    return countryName(word);
-  }
-  return (word || '').replace(/_/g, ' ');
-}
-
-function keywordMatches(keyword='', query='') {
-  let normalizedQuery = query.toLowerCase().replace(/\W*/, '');
-  return keyword.indexOf(normalizedQuery) !== -1;
-}
-
 function initCountryNameMapping() {
   let m = {};
   for (let country of countries) {
@@ -29,6 +17,18 @@ function countryName(code) {
   } else {
     return code;
   }
+}
+
+function humanize(word, category) {
+  if (word.length === 2 && category === 'flags') {
+    return countryName(word);
+  }
+  return (word || '').replace(/_/g, ' ');
+}
+
+function keywordMatches(keyword='', query='') {
+  let normalizedQuery = query.toLowerCase().replace(/\W*/, '');
+  return keyword.indexOf(normalizedQuery) !== -1;
 }
 
 export default Ember.Service.extend({

--- a/app/emoji-store/service.js
+++ b/app/emoji-store/service.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import emojilib from 'npm:emojilib';
+import countries from 'npm:isoc';
 
 function humanize(category) {
   return (category || '').replace(/_/g, ' ');
@@ -8,6 +9,23 @@ function humanize(category) {
 function keywordMatches(keyword='', query='') {
   let normalizedQuery = query.toLowerCase().replace(/\W*/, '');
   return keyword.indexOf(normalizedQuery) !== -1;
+}
+
+function initCountryNameMapping() {
+  let m = {};
+  for (let country of countries) {
+    m[country.alpha2] = country;
+  }
+  return m;
+}
+
+function countryName(code) {
+  let c = countryName.c || (countryName.c = initCountryNameMapping());
+  if (c[code] !== undefined) {
+    return c[code].name.short;
+  } else {
+    return code;
+  }
 }
 
 export default Ember.Service.extend({
@@ -24,7 +42,10 @@ export default Ember.Service.extend({
   seedEmoji() {
     for (let name of Object.keys(emojilib.lib)) {
       let {char, category, keywords} = emojilib.lib[name];
-      let emoji = {name: humanize(name), char};
+      let emoji = {
+        name: (category === 'flags')?countryName(name.toUpperCase()):humanize(name),
+        char,
+      };
       if (!char) {
         continue;
       }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "emojilib": "^2.0.2",
     "eslint-config-ember": "0.0.5",
     "loader.js": "^4.0.1"
+  },
+  "dependencies": {
+    "isoc": "0.0.1"
   }
 }

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -32,3 +32,13 @@ test('search for horse emoji', function (assert) {
     assert.ok(characters.has('🐴'), 'horse emoji found');
   });
 });
+
+test('search for flag emoji (HU)', function (assert) {
+  visit('/');
+
+  fillIn('input', 'hungary');
+  andThen(() => {
+    assert.equal(Ember.$('.emoji-name').length, 1, '1 Hungarian flag found');
+    assert.equal(Ember.$('.emoji-name').text(), 'Hungary', 'Emoji has correct name')
+  });
+});

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -39,6 +39,7 @@ test('search for flag emoji (HU)', function (assert) {
   fillIn('input', 'hungary');
   andThen(() => {
     assert.equal(Ember.$('.emoji-name').length, 1, '1 Hungarian flag found');
-    assert.equal(Ember.$('.emoji-name').text(), 'Hungary', 'Emoji has correct name')
+    assert.equal(Ember.$('.emoji-name').text(), 'Hungary',
+      'Emoji has correct name');
   });
 });


### PR DESCRIPTION
This `ES6` thing is pretty new to me and my javascript is pretty weak in general so feel free to suggest improvements.

Here's a screenshot of how the feature looks like:
![unicode_party_the_unicode_emoji_search_engine_-_2016-08-05_17 55 06](https://cloud.githubusercontent.com/assets/6345/17442417/f2e74c7e-5b35-11e6-97a3-25d370057ecb.png)

Thanks.