### PR TITLE
Update to latest emojilib (2.2.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-keyboard-service": "0.3.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "emojilib": "^2.0.2",
+    "emojilib": "^2.2.6",
     "eslint-config-ember": "0.0.5",
     "loader.js": "^4.0.1"
   },


### PR DESCRIPTION
The latest emojilib seems to add information about the fitzpatrick scale, which should make it easier to implement #23.