### PR TITLE
Change 'click to copy' message when touchscreen is detected

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
           <div class="emoji-tile" x-on:click="copy(emoji.char)">
             <div class="emoji-char" x-text="emoji.char">😀</div>
             <div class="emoji-name" x-text="emoji.name">grinning face</div>
-            <div class="emoji-copy">Click to Copy</div>
+            <div class="emoji-copy" x-text="window.matchMedia('(pointer: coarse)').matches?'Tap to Copy':'Click to Copy'">Click to Copy</div>
           </div>
         </template>
       </section>


### PR DESCRIPTION
Great job on the rewrite, it's a lot easier to get a local install running (and to hack/debug it) 👍🏻 

I've been playing around the new codebase trying to get another PR for #23 and thought I'd contribute a small change first:

If a touchscreen is detected (using the [pointer media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer)) then the text "Click to Copy" is changed to "Tap to Copy".