### PR TITLE
Fix website URL in opensearch.xml

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -5,5 +5,5 @@
   <Url type="text/html" method="get" template="https://unicode.party/?query={searchTerms}"/>
   <Image width="16" height="16">https://unicode.party/favicon.ico</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <moz:SearchForm>https://twitter.com/search-home</moz:SearchForm>
+  <moz:SearchForm>https://unicode.party/</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/OpenSearch), the `moz:SearchForm` tag should contain:

> The URL for the site's search initiation page for the plugin. This lets Firefox users visit the web site, and search from the site directly.