### PR TITLE
Fixes #23 -- Add a selector for skin tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,12 +40,27 @@
                  @keyup.enter.window="if (document.activeElement === $el) { $el.blur() } else { $el.select() }">
           <label for="query">Search</label>
         </div>
+
+        <div class="form-element">
+          <select id="skintone"
+                  x-model="currentSkinToneChar"
+                  :class="{ active: currentSkinToneChar !== skinTones.none}"
+                  x-init="$nextTick(() => { loadSkinToneFromLocalStorage() })">
+            <template x-for="[name, modifier] in Object.entries(skinTones)">
+              <option :value="modifier"
+                      x-text="modifier + ' ' + toKebabCase(name)"></option>
+            </template>
+          </select>
+          <label for="skintone">Skin tone</label>
+        </div>
       </form>
 
       <section class="emoji-tiles">
         <template x-for="emoji in filteredItems.slice(0, 40)">
-          <div class="emoji-tile" x-on:click="copy(emoji.char)">
-            <div class="emoji-char" x-text="emoji.char">😀</div>
+          <div class="emoji-tile"
+               :class="{ 'skintone-enabled': emoji.skinTone }"
+               x-on:click="copy(withSkinTone(emoji))">
+            <div class="emoji-char" x-text="withSkinTone(emoji)">😀</div>
             <div class="emoji-name" x-text="emoji.name">grinning face</div>
             <div class="emoji-copy" x-text="window.matchMedia('(pointer: coarse)').matches?'Tap to Copy':'Click to Copy'">Click to Copy</div>
           </div>

--- a/styles/_search.scss
+++ b/styles/_search.scss
@@ -38,6 +38,13 @@ form[role="search"] {
     }
   }
 
+  label[for="skintone"] {
+    // workaround for the issue where you need to click twice to open the skintone dropdown
+    // (once to focus the <select> and let the label move up out of the way, once to actually
+    //  open the dropdown)
+    pointer-events: none;
+  }
+
   .form-element {
     position: relative;
 

--- a/styles/_search.scss
+++ b/styles/_search.scss
@@ -13,19 +13,28 @@ form[role="search"] {
   height: 3rem;
   margin-bottom: 3rem;
 
-  #query {
-    // The complicated width/max-width makes the input the same width as:
-    // * 1 emoji tile on small screens
-    // * 1 emoji tile on medium screens
-    // * 2 emoji tiles on large screens
-    box-sizing: border-box;
-    max-width: 90vw;
-    width: $medium-screen;
+  // The gap matches the .emoji-tiles grid-gap
+  gap: 2rem;
+  @media (min-width: $large-screen) {
+    gap: 2.3rem;
+  }
+
+  :first-child {
+    // On small screens, the search input takes the whole remaining space
+    // On medium screens, the input spans 1 emoji tile (out of two per row)
+    // On large screens it spans 2 tiles (out of four per row)
+    flex: 1 1;
     @media (min-width: $medium-screen) {
-      max-width: calc(45vw - 1rem);
+      flex: 0;
+      flex-basis: calc(50% - 1rem);
     }
     @media (min-width: $large-screen) {
-      width: calc(math.div($large-screen, 2) - 1.15rem);
+      flex-basis: calc(50% - 1.15rem);
+    }
+
+    input {
+      box-sizing: border-box;
+      width: 100%;
     }
   }
 
@@ -44,9 +53,10 @@ form[role="search"] {
       cursor: text;
     }
 
-    input {
+    input, select {
       transition: background 0.3s cubic-bezier(.64,.09,.08,1);
       color: darken(teal, 20%);
+      background: unset;
       padding: 1rem;
       border: none {
         bottom: solid 1px teal;


### PR DESCRIPTION
Features:

- Live updates of tiles when changing the skin tone
- Only emojis that supports the skin tone modifier characters are affected
- Selected skin tone persists between searches and sessions (using the browser's `localStorage`)


Limitations:

- Because of the way the fancy labels are implemented, you sometimes need to click twice on the skin tone selector to open it (once to focus, once to open the dropdown)
- Skin tone support on individual emojis is a boolean (supplied by the library) and doesn't consider the user's actual support (it can vary based on system or browser version). This can result in slightly broken tiles where both the original emoji and the skin tone character are shown side by side instead of combined.  I think it's acceptable considering that this "slightly broken" behavior already appears for some "advanced" combined emoji (for example the "service dog" emoji doesn't render correctly for me on chromium but works on firefox on the same machine).