### PR TITLE
Make emoji tiles more responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,8 @@
       </template>
     </div>
     <header class="header">
-      <a href="/" class="active">
-        <h1 class="header-title">Unicode Party <span class="header-balloon">🎈</span></h1>
+        <h1 class="header-title"><a href="/" class="active">Unicode Party <span class="header-balloon">🎈</span></a></h1>
         <h5 class="header-subtitle">The Unicode Emoji Search Engine</h5>
-      </a>
     </header>
     <main>
       <form role="search" @submit.prevent>

--- a/styles/_emoji-tiles.scss
+++ b/styles/_emoji-tiles.scss
@@ -28,12 +28,21 @@ $emoji-font-size: 6rem;
       color: midnightblue;
     }
   }
+  display: grid;
+  // That magic 1.32 multiplier seems to make the right max width
+  grid-template-columns: $emoji-font-size*1.32 auto;
+  grid-auto-columns: 1fr;
+  column-gap: 1em;
+  row-gap: 1em;
 }
 
 .emoji-char {
   @extend .emoji-text;
   font-size: $emoji-font-size;
-  float: left;
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .emoji-name {
@@ -42,18 +51,20 @@ $emoji-font-size: 6rem;
   -ms-user-select: none;
   user-select: none;
   text-transform: capitalize;
-  float: right;
   text-align: right;
-  max-width: 50%;
+  grid-column: 2;
+  grid-row: 1;
 }
 
 .emoji-copy {
-  padding-top: $emoji-font-size - 1rem;
   text-align: right;
   color: gray;
-  .no-clipboard & {
-    display: none;
-  }
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding-bottom: 1rem;
 }
 
 .emoji-tile {

--- a/styles/_emoji-tiles.scss
+++ b/styles/_emoji-tiles.scss
@@ -29,8 +29,8 @@ $emoji-font-size: 6rem;
     }
   }
   display: grid;
-  // That magic 1.32 multiplier seems to make the right max width
-  grid-template-columns: $emoji-font-size*1.32 auto;
+  // That magic 1.2 multiplier seems to make the right max width
+  grid-template-columns: $emoji-font-size*1.2 auto;
   grid-auto-columns: 1fr;
   column-gap: 1em;
   row-gap: 1em;


### PR DESCRIPTION
Changes:

- Use a CSS grid to make the emoji character take up the same height as the two text items
- Set width of emoji character to 1.2x the font size (it seems to work on my machine 😅)
- Set overflow to hidden and disable text wrapping for emoji character so more than 1 character never shows
- Make clickable header area much smaller

I'm not sure how to confirm that 1.2x will work properly as the character width.