### PR TITLE
Add support for Unicode 15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
         "alpinejs": "^3.10.2"
       },
       "devDependencies": {
-        "emojilib": "3.0.0",
+        "emojilib": "^4.0.1",
         "sass": "^1.52.2",
-        "unicode-emoji-json": "0.2.1",
+        "unicode-emoji-json": "^0.6.0",
         "vite": "^2.9.9"
       }
     },
@@ -100,10 +100,11 @@
       }
     },
     "node_modules/emojilib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-3.0.0.tgz",
-      "integrity": "sha512-Opb7qfOR/dn0u+ueVYrmCnxrHAgLmaDtAiQ9ogYQcEhwG+MPnuilZey5Y6VVlVXk531JRIGKYIUhySgNqLCfiw==",
-      "dev": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-4.0.1.tgz",
+      "integrity": "sha512-zVY5JGxycujUimHkBn2lg5NCVwASJiQA2fhKfDPgyDFmNTftiw6KdOcq2fQt1HCVw0YeYW/ccYxQHQNjZpNeuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.14.42",
@@ -740,10 +741,11 @@
       }
     },
     "node_modules/unicode-emoji-json": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.2.1.tgz",
-      "integrity": "sha512-4X736t5oVw33kPIPo9F0UUQqUY2gEtAwVFFnE7LXfExhPeWO64FahKw6yFb6gps7Ex7cat5LJPemVEzdk8pWug==",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.6.0.tgz",
+      "integrity": "sha512-tAYF+EsOxa8jo/XPNYHRX7Nc8uoII+/edIpHM4DQI4nMp3AuRmwGZhL8fEBe0kUk0zHK+6wiwxxxNwfW5ap2Tg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "2.9.9",
@@ -847,9 +849,9 @@
       }
     },
     "emojilib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-3.0.0.tgz",
-      "integrity": "sha512-Opb7qfOR/dn0u+ueVYrmCnxrHAgLmaDtAiQ9ogYQcEhwG+MPnuilZey5Y6VVlVXk531JRIGKYIUhySgNqLCfiw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-4.0.1.tgz",
+      "integrity": "sha512-zVY5JGxycujUimHkBn2lg5NCVwASJiQA2fhKfDPgyDFmNTftiw6KdOcq2fQt1HCVw0YeYW/ccYxQHQNjZpNeuw==",
       "dev": true
     },
     "esbuild": {
@@ -1208,9 +1210,9 @@
       }
     },
     "unicode-emoji-json": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.2.1.tgz",
-      "integrity": "sha512-4X736t5oVw33kPIPo9F0UUQqUY2gEtAwVFFnE7LXfExhPeWO64FahKw6yFb6gps7Ex7cat5LJPemVEzdk8pWug==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.6.0.tgz",
+      "integrity": "sha512-tAYF+EsOxa8jo/XPNYHRX7Nc8uoII+/edIpHM4DQI4nMp3AuRmwGZhL8fEBe0kUk0zHK+6wiwxxxNwfW5ap2Tg==",
       "dev": true
     },
     "vite": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "emojilib": "3.0.0",
+    "emojilib": "^4.0.1",
     "sass": "^1.52.2",
-    "unicode-emoji-json": "0.2.1",
+    "unicode-emoji-json": "^0.6.0",
     "vite": "^2.9.9"
   },
   "dependencies": {


### PR DESCRIPTION
Tested it locally and it seems to work well.

There's a newer version of `unicode-emoji-json` available but it's not compatible with `emojilib` yet (see https://github.com/muan/emojilib/issues/232)